### PR TITLE
fixed a performance problem caused by path watching

### DIFF
--- a/src/assets/js/utils/scripts.js
+++ b/src/assets/js/utils/scripts.js
@@ -784,7 +784,9 @@ export const watchFolderPath = (path, vars, callback) => {
           vars.chokidarConfig(path, ignore),
         );
 
-        vars.chokidarWatcher.on('all', callback);
+        vars.chokidarWatcher.on('ready', () => {
+          vars.chokidarWatcher.on('all', callback);
+        });
       }
     });
   } else {
@@ -794,7 +796,9 @@ export const watchFolderPath = (path, vars, callback) => {
         vars.chokidarConfig(path, ignore),
       );
 
-      vars.chokidarWatcher.on('all', callback);
+      vars.chokidarWatcher.on('ready', () => {
+        vars.chokidarWatcher.on('all', callback);
+      });
     }
   }
 };


### PR DESCRIPTION
in the folder and scripts window, we watch paths to be able to detect when there are changes (maybe when files or folders are deleted in the host computer) so we can update our app. However a particular watcher configuration causes the watcher event to be triggered multiple times, this causes  a huge performance problem when analyzing large codebases. This PR fixes that