### PR TITLE
refactor query processing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,7 @@ module.exports = {
 		'func-names': 'off',
 		'default-param-last': 'off',
 		'no-unneeded-ternary': 'off',
+    'no-underscore-dangle': 'off',
 		'import/prefer-default-export': 'off',
 		'import/no-cycle': 'off',
 		'import/no-self-import': 'off',
@@ -73,6 +74,9 @@ module.exports = {
 					'./.erb/configs/webpack.config.eslint.js',
 				),
 			},
+      react: {
+        version: "detect"
+      },
 			typescript: {},
 		},
 		// 'import/parsers': {

--- a/src/main/window.js
+++ b/src/main/window.js
@@ -32,7 +32,7 @@ const devSetup = async () => {
 
 export const createWindow = async () => {
 	// await devSetup();
-	devSetup(); // uncomment this line to keep devtools always open
+	// devSetup(); // uncomment this line to keep devtools always open
 
 	const { position, size } = getWindowPosition();
 

--- a/src/renderer/assets/js/utils/scripts.js
+++ b/src/renderer/assets/js/utils/scripts.js
@@ -15,12 +15,13 @@ import {
 } from './defaultVariables';
 import {
 	deQueueQuery,
+  deQueueScriptsQuery,
 	getQueryResult,
+  setScriptsResults,
 	postQuery,
 	setResults,
 	resetQueue,
 	enQueueQuery,
-	deQueueScriptsQuery,
 	setQueryShortcut,
 } from '../../../store/actions/queryActions';
 import {
@@ -165,19 +166,6 @@ export const deepClone = obj => {
 	return new_obj;
 };
 
-export const getResultObjWithPostQueryKey = (results, post_query_key) => {
-	let res;
-	Object.keys(results).some(key => {
-		if (key && results[key].post_query_uuid === post_query_key) {
-			res = key;
-			return true;
-		}
-		return false;
-	});
-
-	return res;
-};
-
 export const getActiveProject = () => {
 	const { projects } = store.getState().workspace;
 	let activeProject = null;
@@ -244,39 +232,35 @@ export const parseProject = data => {
 	return { name, inputPath, path, cpg, language };
 };
 
-const performPostQuery = (store, results, key) => {
-	let post_query;
-	const result = results[key];
+const performPostQuery = (result, key) => {
+  let post_query;
 
-	if (
-		result.query.startsWith(manCommands.switchWorkspace) ||
-		result.query === 'project'
-	) {
-		post_query = 'workspace';
-	} else {
-		post_query = 'project';
-	}
+  if (
+    result.query.startsWith(manCommands.switchWorkspace) ||
+    result.query === 'project'
+  ) {
+    post_query = 'workspace';
+  } else {
+    post_query = 'project';
+  }
 
-	store.dispatch(postQuery(post_query, key));
+  store.dispatch(postQuery(post_query, key));
 };
 
-const setQueryResult = (data, store, key, results) => {
+const setQueryResult = (data, key, results) => {
 	if (results[key].t_0 && !results[key].t_1) {
-		results[key].t_1 = performance.now();
+		results[key].t_1 = new Date().getTime();
 	}
 
 	if (!results[key].result.stdout && !results[key].result.stderr) {
-		if (!data) {
-			results[key].result.stderr = 'query failed';
-		} else {
-			if (data.stdout) {
-				results[key].result.stdout = data.stdout;
-			}
 
-			if (data.stderr) {
-				results[key].result.stderr = data.stderr;
-			}
-		}
+    if (data.stdout) {
+      results[key].result.stdout = data.stdout;
+    }
+
+    if (data.stderr) {
+      results[key].result.stderr = data.stderr;
+    }
 
 		store.dispatch(setResults(results));
 	} else if (
@@ -284,7 +268,6 @@ const setQueryResult = (data, store, key, results) => {
 		results[key].query === 'project'
 	) {
 		if (
-			!data &&
 			!results[key].result.stdout &&
 			!results[key].result.stderr
 		) {
@@ -297,7 +280,6 @@ const setQueryResult = (data, store, key, results) => {
 		store.dispatch(setResults(results));
 	} else {
 		if (
-			!data &&
 			!results[key].result.stdout &&
 			!results[key].result.stderr
 		) {
@@ -310,32 +292,64 @@ const setQueryResult = (data, store, key, results) => {
 	}
 };
 
-export const handleWebSocketResponse = data => {
-	store.dispatch(getQueryResult(data.utf8Data)).then(data => {
-		const { results } = store.getState().query;
-		let key = data.uuid;
-		let result_obj = results[key];
+const setScriptsQueryResult = (data, key, results) => {
+	if (results[key].t_0 && !results[key].t_1) {
+		results[key].t_1 = new Date().getTime();
+	}
 
-		if (!result_obj) {
-			key = getResultObjWithPostQueryKey(results, data.uuid);
-			result_obj = results[key];
-		}
-
-		if (result_obj) {
-			if (!result_obj.result.stdout && !result_obj.result.stderr) {
-				setQueryResult(data, store, key, results);
-				if (result_obj.origin === 'script') {
-					store.dispatch(deQueueScriptsQuery());
-					addToQueue(addWorkSpaceQueryToQueue());
-				} else {
-					performPostQuery(store, results, key);
-				}
-			} else {
-				setQueryResult(data, store, key, results);
-				store.dispatch(deQueueQuery());
+			if (data.stdout) {
+				results[key].result.stdout = data.stdout;
 			}
-		}
-	});
+
+			if (data.stderr) {
+				results[key].result.stderr = data.stderr;
+			}
+
+		store.dispatch(setScriptsResults(results));
+};
+
+export const handleWebSocketResponse = data => {
+  store.dispatch(getQueryResult(data.utf8Data)).then(data => {
+    const { results, scriptsResults } = store.getState().query;
+    let key = data?.uuid;
+    if(!key) return;
+
+    let latest = results[key];
+
+    if(!latest){
+      latest = scriptsResults[key];
+    };
+
+    if(!latest){
+      const result_keys = Object.keys(results);
+      key = result_keys[result_keys.length - 1];
+      const _latest = results[key];
+      if(_latest.post_query_uuid === data.uuid){
+        latest = _latest
+      };
+    };
+
+    if(latest && latest.origin === "script"){
+
+      if (!latest.result.stdout && !latest.result.stderr) {
+        setScriptsQueryResult(data, key, scriptsResults);
+        store.dispatch(deQueueScriptsQuery());
+      };
+
+    }else if(latest && latest.origin !== "script"){
+
+      if (!latest.result.stdout && !latest.result.stderr) {
+        setQueryResult(data, key, results);
+        performPostQuery(results[key], key);
+      } else {
+        setQueryResult(data, key, results);
+        store.dispatch(deQueueQuery());
+      }
+
+    }
+  }).catch(() => {
+    // handleAPIQueryError(err);
+  });
 };
 
 export const handleCertificateError = () => {
@@ -1024,40 +1038,40 @@ export const isQueryResultToOpenSynthFile = latest => {
 	return { synth_file_path, content };
 };
 
-export const isScriptQueryResultToOpenSynthFile = async result => {
-	let synth_file_path = false;
-	let content = false;
+// export const isScriptQueryResultToOpenSynthFile = async result => {
+// 	let synth_file_path = false;
+// 	let content = false;
 
-	if (
-		result?.result?.stdout &&
-		typeof result.result.stdout === 'string' &&
-		!result.query.startsWith('import') &&
-		result.result.stdout.includes('.json')
-	) {
-		try {
-			synth_file_path = `${
-				result.query.split('`').join('').split('.')[0]
-			}.sc - ${syntheticFiles[2]}`;
-			content = result.result.stdout.split('=')[1].split('"')[1];
-			content = await readFile(content).catch(() => {
-				synth_file_path = false;
-				handleSetToast({
-					icon: 'warning-sign',
-					intent: 'danger',
-					message:
-						"script report file path returned by script run doesn't exist",
-				});
+// 	if (
+// 		result?.result?.stdout &&
+// 		typeof result.result.stdout === 'string' &&
+// 		!result.query.startsWith('import') &&
+// 		result.result.stdout.includes('.json')
+// 	) {
+// 		try {
+// 			synth_file_path = `${
+// 				result.query.split('`').join('').split('.')[0]
+// 			}.sc - ${syntheticFiles[2]}`;
+// 			content = result.result.stdout.split('=')[1].split('"')[1];
+// 			content = await readFile(content).catch(() => {
+// 				synth_file_path = false;
+// 				handleSetToast({
+// 					icon: 'warning-sign',
+// 					intent: 'danger',
+// 					message:
+// 						"script report file path returned by script run doesn't exist",
+// 				});
 
-				return false;
-			});
-		} catch (e) {
-			synth_file_path = false;
-			content = false;
-		}
-	}
+// 				return false;
+// 			});
+// 		} catch (e) {
+// 			synth_file_path = false;
+// 			content = false;
+// 		}
+// 	}
 
-	return { synth_file_path, content };
-};
+// 	return { synth_file_path, content };
+// };
 
 export const isQueryResultToCloseSynthFile = async () => {
 	const paths_to_close = [];
@@ -1524,18 +1538,18 @@ export const handleFontSizeChange = (doc, fontSize) => {
 	doc.children[0].children[1].style.fontSize = fontSize;
 };
 
-export const getScriptResult = (uuids, results) => {
-	let result;
+// export const getScriptResult = (uuids, results) => {
+// 	let result;
 
-	for (let i = uuids.length - 1; i >= 0; i -= 1) {
-		if (results[uuids[i]].origin === 'script') {
-			result = results[uuids[i]];
-			break;
-		}
-	}
+// 	for (let i = uuids.length - 1; i >= 0; i -= 1) {
+// 		if (results[uuids[i]].origin === 'script') {
+// 			result = results[uuids[i]];
+// 			break;
+// 		}
+// 	}
 
-	return result;
-};
+// 	return result;
+// };
 
 export const generateScriptImportQuery = async (
 	path_to_script,

--- a/src/renderer/components/binary_viewer/binaryViewerScripts.js
+++ b/src/renderer/components/binary_viewer/binaryViewerScripts.js
@@ -65,7 +65,7 @@ export const getMethodPositionInDecompiledMethodsEditor = (
 		code = code.split(/\n/);
 		const str_to_search = code[0].startsWith('/*') ? code[1] : code[0];
 		const range =
-			editor._modelData.model.findMatches(str_to_search)[0].range; // eslint-disable-line no-underscore-dangle
+			editor._modelData.model.findMatches(str_to_search)[0].range;
 		range.startLineNumber = code[0].startsWith('/*')
 			? range.startLineNumber - 1
 			: range.startLineNumber;

--- a/src/renderer/components/queries_stats/QueriesStats.jsx
+++ b/src/renderer/components/queries_stats/QueriesStats.jsx
@@ -36,9 +36,9 @@ function QueriesStats(props) {
 
 	React.useEffect(() => {
 		if (props.results) {
-			handleSetState(countQueries(props.results));
-		}
-	}, [props.results]);
+			handleSetState(countQueries(props.results, props.scriptsResults));
+		};
+	}, [props.results, props.scriptsResults]);
 
 	React.useEffect(() => {
 		if (state.queriesStatsPopoverIsOpen && props.results) {
@@ -46,7 +46,7 @@ function QueriesStats(props) {
 				() =>
 					setState(state => ({
 						...state,
-						...updateQueriesStats(props.results),
+						...updateQueriesStats(props.results, props.scriptsResults),
 					})),
 				100,
 			);
@@ -149,7 +149,7 @@ function QueriesStats(props) {
 				data-test="queries-stats"
 			>
 				<div className={classes.refreshIconContainerStyle}>
-					{!queueEmpty(props.queue) ? (
+					{!queueEmpty(props.queue) || !queueEmpty(props.scriptsQueue) ? (
 						<Icon
 							icon="refresh"
 							className={clsx(
@@ -167,7 +167,7 @@ function QueriesStats(props) {
 				<p className={classes.queriesStatsStyle}>
 					{nFormatter(queriesCount)}
 				</p>
-				{!queueEmpty(props.queue) ? <div>running...</div> : null}
+				{!queueEmpty(props.queue) || !queueEmpty(props.scriptsQueue) ? <div>running...</div> : null}
 			</div>
 		</Popover2>
 	);
@@ -175,7 +175,9 @@ function QueriesStats(props) {
 
 const mapStateToProps = state => ({
 	results: querySelectors.selectResults(state),
+  scriptsResults: querySelectors.selectScriptsResults(state),
 	queue: querySelectors.selectQueue(state),
+  scriptsQueue: querySelectors.selectScriptsQueue(state),
 	prefersDarkMode: settingsSelectors.selectPrefersDarkMode(state),
 });
 

--- a/src/renderer/components/queries_stats/queriesStatsScripts.js
+++ b/src/renderer/components/queries_stats/queriesStatsScripts.js
@@ -1,20 +1,21 @@
-export const countQueries = results => ({
-	queriesCount: Object.keys(results).length,
+export const countQueries = (results, scriptsResults) => ({
+	queriesCount: Object.keys(results).length + Object.keys(scriptsResults).length,
 });
 
-export const updateQueriesStats = results => {
-	const queriesStats = [];
+export const updateQueriesStats = (results, scriptsResults) => {
+  let queriesStats = [
+    ...Object.keys(results).map(key=>results[key]),
+    ...Object.keys(scriptsResults).map(key=>scriptsResults[key])
+  ];
 
-	Object.keys(results).forEach(key => {
-		const result = results[key];
-		queriesStats.push({
-			query: result.query,
-			t_elapsed: result.t_1
-				? result.t_1 - result.t_0
-				: performance.now() - result.t_0,
-			completed: !!result.t_1,
-		});
-	});
+  queriesStats.sort((result1, result2)=> result1.t_0 - result2.t_0);
+  queriesStats = queriesStats.map(result=>({
+    query: result.query,
+    t_elapsed: result.t_1
+      ? result.t_1 - result.t_0
+      : new Date().getTime() - result.t_0,
+    completed: !!result.t_1,
+  }));
 
 	return { queriesStats };
 };

--- a/src/renderer/renderless/QueryProcessor.jsx
+++ b/src/renderer/renderless/QueryProcessor.jsx
@@ -4,7 +4,7 @@ import * as settingsSelectors from '../store/selectors/settingsSelectors';
 import * as querySelectors from '../store/selectors/querySelectors';
 import * as statusSelectors from '../store/selectors/statusSelectors';
 import * as queryActions from '../store/actions/queryActions';
-import { shouldRunQuery, processScriptResult } from './queryProcessorScripts';
+import { shouldRunQuery } from './queryProcessorScripts';
 import {
 	addToQueue,
 	addWorkSpaceQueryToQueue,
@@ -71,9 +71,9 @@ function QueryProcessor(props) {
 		props.connected && addToQueue(addWorkSpaceQueryToQueue());
 	}, [props.connected, props.server, props.websocket]);
 
-	React.useEffect(() => {
-		processScriptResult(state.prev_results, props.results, handleSetState);
-	}, [props.results]);
+	// React.useEffect(() => {
+	// 	processScriptResult(state.prev_results, props.results, handleSetState);
+	// }, [props.results]);
 
 	return null;
 }
@@ -92,6 +92,7 @@ const mapDispatchToProps = dispatch => ({
 	peekQueue: () => dispatch(queryActions.peekQueue()),
 	peekScriptsQueue: () => dispatch(queryActions.peekScriptsQueue()),
 	enQueueQuery: query => dispatch(queryActions.enQueueQuery(query)),
+  enQueueScriptsQuery: query => dispatch(queryActions.enQueueScriptsQuery(query))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(QueryProcessor);

--- a/src/renderer/renderless/queryProcessorScripts.js
+++ b/src/renderer/renderless/queryProcessorScripts.js
@@ -1,10 +1,9 @@
-import {
-	getScriptResult,
-	handleSetToast,
-	isScriptQueryResultToOpenSynthFile,
-	openSyntheticFile,
-	deepClone,
-} from '../assets/js/utils/scripts';
+// import {
+// 	getScriptResult,
+// 	handleSetToast,
+// 	openSyntheticFile,
+// 	deepClone,
+// } from '../assets/js/utils/scripts';
 
 export const shouldRunQuery = (prev_queue, queue, query) => {
 	const prev_queue_count = prev_queue ? Object.keys(prev_queue).length : 0;
@@ -18,50 +17,50 @@ export const shouldRunQuery = (prev_queue, queue, query) => {
 	}
 };
 
-export const shouldAlertScriptRunSuccessful = (prev_results, results) => {
-	const prev_uuids = Object.keys(prev_results);
-	const uuids = Object.keys(results);
+// export const shouldAlertScriptRunSuccessful = (prev_results, results) => {
+// 	const prev_uuids = Object.keys(prev_results);
+// 	const uuids = Object.keys(results);
 
-	const prev_last_script_result = getScriptResult(prev_uuids, prev_results);
+// 	const prev_last_script_result = getScriptResult(prev_uuids, prev_results);
 
-	const last_script_result = getScriptResult(uuids, results);
+// 	const last_script_result = getScriptResult(uuids, results);
 
-	if (
-		JSON.stringify(prev_last_script_result) !==
-			JSON.stringify(last_script_result) &&
-		(last_script_result.result.stdout ||
-			last_script_result.result.stderr) &&
-		!last_script_result.query.includes('import') &&
-		last_script_result.t_0 &&
-		last_script_result.t_1
-	) {
-		return last_script_result;
-	}
-	return false;
-};
+// 	if (
+// 		JSON.stringify(prev_last_script_result) !==
+// 			JSON.stringify(last_script_result) &&
+// 		(last_script_result.result.stdout ||
+// 			last_script_result.result.stderr) &&
+// 		!last_script_result.query.includes('import') &&
+// 		last_script_result.t_0 &&
+// 		last_script_result.t_1
+// 	) {
+// 		return last_script_result;
+// 	}
+// 	return false;
+// };
 
-export const processScriptResult = async (
-	prev_results,
-	results,
-	handleSetState,
-) => {
-	const script_result = shouldAlertScriptRunSuccessful(prev_results, results);
+// export const processScriptResult = async (
+// 	prev_results,
+// 	results,
+// 	handleSetState,
+// ) => {
+// 	const script_result = shouldAlertScriptRunSuccessful(prev_results, results);
 
-	if (script_result) {
-		handleSetToast({
-			icon: 'info-sign',
-			intent: 'success',
-			message: 'script ran successfully',
-		});
+// 	if (script_result) {
+// 		handleSetToast({
+// 			icon: 'info-sign',
+// 			intent: 'success',
+// 			message: 'script ran successfully',
+// 		});
 
-		const { synth_file_path, content } =
-			await isScriptQueryResultToOpenSynthFile(script_result);
-		synth_file_path &&
-			content &&
-			openSyntheticFile(synth_file_path, content);
-	}
+// 		const { synth_file_path, content } =
+// 			await isScriptQueryResultToOpenSynthFile(script_result);
+// 		synth_file_path &&
+// 			content &&
+// 			openSyntheticFile(synth_file_path, content);
+// 	}
 
-	handleSetState({
-		prev_results: results ? deepClone(results) : {},
-	});
-};
+// 	handleSetState({
+// 		prev_results: results ? deepClone(results) : {},
+// 	});
+// };

--- a/src/renderer/store/reducers/queryReducers.js
+++ b/src/renderer/store/reducers/queryReducers.js
@@ -5,6 +5,7 @@ const workerPool = Pool(() => spawn(new Worker(workerURL)));
 
 export const default_state = {
 	results: {},
+  scriptsResults: {},
 	queue: {},
 	scriptsQueue: {},
 	queryShortcut: {},
@@ -17,14 +18,26 @@ const query = (state = default_state, action) => {
 			return {
 				queue: state.queue,
 				results: { ...state.results, ...action.payload },
+        scriptsResults: state.scriptsResults,
 				scriptsQueue: state.scriptsQueue,
 				queryShortcut: state.queryShortcut,
 				workerPool: state.workerPool,
 			};
 
+      case 'SET_SCRIPTS_RESULTS':
+        return {
+          queue: state.queue,
+          results: state.results,
+          scriptsResults: { ...state.scriptsResults, ...action.payload },
+          scriptsQueue: state.scriptsQueue,
+          queryShortcut: state.queryShortcut,
+          workerPool: state.workerPool,
+        };
+
 		case 'SET_QUEUE':
 			return {
 				results: state.results,
+        scriptsResults: state.scriptsResults,
 				queue: { ...state.queue, ...action.payload },
 				scriptsQueue: state.scriptsQueue,
 				queryShortcut: state.queryShortcut,
@@ -34,6 +47,7 @@ const query = (state = default_state, action) => {
 		case 'RESET_QUEUE':
 			return {
 				results: state.results,
+        scriptsResults: state.scriptsResults,
 				queue: action.payload,
 				scriptsQueue: state.scriptsQueue,
 				queryShortcut: state.queryShortcut,
@@ -43,6 +57,7 @@ const query = (state = default_state, action) => {
 		case 'SET_SCRIPTS_QUEUE':
 			return {
 				results: state.results,
+        scriptsResults: state.scriptsResults,
 				queue: state.queue,
 				scriptsQueue: { ...state.scriptsQueue, ...action.payload },
 				queryShortcut: state.queryShortcut,
@@ -52,6 +67,7 @@ const query = (state = default_state, action) => {
 		case 'RESET_SCRIPTS_QUEUE':
 			return {
 				results: state.results,
+        scriptsResults: state.scriptsResults,
 				queue: state.queue,
 				scriptsQueue: action.payload,
 				queryShortcut: state.queryShortcut,
@@ -61,6 +77,7 @@ const query = (state = default_state, action) => {
 		case 'SET_QUERY_SHORTCUT':
 			return {
 				results: state.results,
+        scriptsResults: state.scriptsResults,
 				queue: state.queue,
 				scriptsQueue: state.scriptsQueue,
 				queryShortcut: { ...action.payload },

--- a/src/renderer/store/selectors/querySelectors.js
+++ b/src/renderer/store/selectors/querySelectors.js
@@ -6,6 +6,10 @@ export const selectResults = createSelector(
 	[selectQuery],
 	query => query.results,
 );
+export const selectScriptsResults = createSelector(
+  [selectQuery],
+  query => query.scriptsResults,
+);
 export const selectQueue = createSelector([selectQuery], query => query.queue);
 export const selectScriptsQueue = createSelector(
 	[selectQuery],

--- a/src/renderer/views/terminal_window/terminalWindowScripts.js
+++ b/src/renderer/views/terminal_window/terminalWindowScripts.js
@@ -922,7 +922,7 @@ export const sendQueryResultToXTerm = async (results, refs) => {
 		term &&
 		(latest?.result.stdout || latest?.result.stderr) &&
 		!latest?.ignore &&
-		latest.post_query_uuid &&
+    latest.post_query_uuid &&
 		(latest.workspace || latest.project)
 	) {
 		return await handleWriteQueryResult(term, refs, latest); // eslint-disable-line no-return-await


### PR DESCRIPTION
previously rules and normal queries uses different queues but the same result array.
this PR introduces complete separation so rules use different queue and result array, while normal queries use there own different queue and result array.